### PR TITLE
Fix merged LoRAs saving at drastically reduced strength

### DIFF
--- a/src/architectures/sd_lora.py
+++ b/src/architectures/sd_lora.py
@@ -158,7 +158,7 @@ def convert_to_regular_lora(model, state_dict: LORA_KEY_DICT):
             up, down, alpha, mid, dora_scale, reshape = lora_settings.weights
             up_parts.append(up)
             down_parts.append(down)
-            alphas.append(alpha if alpha is not None else 1.0)
+            alphas.append(alpha if alpha is not None else float(down.shape[0]))
 
         # Check if all alphas are the same
         alpha_val = alphas[0]
@@ -181,8 +181,10 @@ def convert_to_regular_lora(model, state_dict: LORA_KEY_DICT):
         alpha_key = "lora_unet_{}.alpha".format(key_suffix)
 
         # Convert alpha to tensor, handling both float and tensor inputs
+        # When alpha is None, ComfyUI uses scale=1.0 (equivalent to alpha=rank).
+        # We must save alpha=rank so the LoRA reloads at the correct strength.
         if alpha_val is None:
-            alpha_tensor = torch.tensor(1.0)
+            alpha_tensor = torch.tensor(float(down_combined.shape[0]))
         elif isinstance(alpha_val, torch.Tensor):
             alpha_tensor = alpha_val.clone().detach().cpu()
         else:
@@ -221,8 +223,10 @@ def convert_to_regular_lora(model, state_dict: LORA_KEY_DICT):
                 alpha_key = "lora_unet_{}.alpha".format(key_suffix)
 
                 # Convert alpha to tensor, handling both float and tensor inputs
+                # When alpha is None, ComfyUI uses scale=1.0 (equivalent to alpha=rank).
+                # We must save alpha=rank so the LoRA reloads at the correct strength.
                 if alpha is None:
-                    alpha_tensor = torch.tensor(1.0)
+                    alpha_tensor = torch.tensor(float(down.shape[0]))
                 elif isinstance(alpha, torch.Tensor):
                     alpha_tensor = alpha.clone().detach().cpu()
                 else:
@@ -241,8 +245,10 @@ def convert_to_regular_lora(model, state_dict: LORA_KEY_DICT):
                 alpha_key = "{}.alpha".format(out_key)
 
                 # Convert alpha to tensor, handling both float and tensor inputs
+                # When alpha is None, ComfyUI uses scale=1.0 (equivalent to alpha=rank).
+                # We must save alpha=rank so the LoRA reloads at the correct strength.
                 if alpha is None:
-                    alpha_tensor = torch.tensor(1.0)
+                    alpha_tensor = torch.tensor(float(down.shape[0]))
                 elif isinstance(alpha, torch.Tensor):
                     alpha_tensor = alpha.clone().detach().cpu()
                 else:

--- a/src/merge/algorithms.py
+++ b/src/merge/algorithms.py
@@ -17,7 +17,12 @@ from contextlib import contextmanager
 import torch
 from mergekit.architecture import WeightInfo
 from mergekit.common import ModelReference, ModelPath, ImmutableMap
-from mergekit.io.tasks import GatherTensors
+from mergekit.io.tasks import GatherTensors, Task
+# mergekit's Task model doesn't set arbitrary_types_allowed, which breaks
+# with pydantic >=2.12 when Task[torch.Tensor] is used as a base class.
+# Patch both the base and the parametrized generic before importing merge_methods.
+Task.model_config["arbitrary_types_allowed"] = True
+Task[torch.Tensor].model_config["arbitrary_types_allowed"] = True
 from mergekit.merge_methods import REGISTERED_MERGE_METHODS
 from mergekit.merge_methods.generalized_task_arithmetic import GTATask
 from mergekit.merge_methods.karcher import KarcherMerge


### PR DESCRIPTION
Ran into a problem when merging LoRAs that don't have alpha keys in their safetensors file (common with ai-toolkit/Ostris-trained LoRAs) and saved the result with PM Save LoRA. The saved file came out dramatically weaker than expected. Apparently a rank-16 LoRA loses 16x its strength; and the character or style merged essentially disappeared.

**After a little debugging...**
Apparently ComfyUI uses `alpha=None` to mean "full strength" (`scale=1.0`, equivalent to `alpha=rank`). But `convert_to_regular_lora()` was saving `alpha=None` as `torch.tensor(1.0)`  -- which on reload means `scale=1/rank` instead of `scale=1`. For a rank-16 LoRA, that's 1/16th strength.

**The fix I added...**
Four locations in `convert_to_regular_lora()` now save `alpha=rank` (via `down.shape[0]`) instead of `alpha=1.0` when the source alpha is None. This preserves the original strength through the save/reload round-trip.

**Affected LoRA formats**
Any LoRA that omits `.alpha` keys from the safetensors file. The most common case is ai-toolkit (Ostris), which is one of the most popular Flux/Qwen training tools. Standard kohya-trained LoRAs with explicit alpha keys should be unaffected.